### PR TITLE
55571 - Implemented Licence tests cases "Register Machines and Generate UUID"

### DIFF
--- a/Backend/UpFluxCollection.postman_collection.json
+++ b/Backend/UpFluxCollection.postman_collection.json
@@ -263,6 +263,7 @@
 													"// Test weak password response\r",
 													"pm.test(\"Weak password response\", function () {\r",
 													"    pm.expect(pm.response.code).to.equal(400);\r",
+													"     // pm.expect(pm.response.code).to.equal(200);\r",
 													"    pm.expect(pm.response.json().message).to.equal(\"Password is too weak\");\r",
 													"});\r",
 													""
@@ -620,6 +621,7 @@
 												"exec": [
 													"pm.test(\"Status code is 401\", function () {\r",
 													"    pm.response.to.have.status(401);\r",
+													"        //pm.response.to.have.status(200);\r",
 													"});\r",
 													"\r",
 													"\r",
@@ -1023,6 +1025,72 @@
 						}
 					],
 					"description": "Validates role-based access control and token authentication to ensure secure access to machine data and shared endpoints while rejecting unauthorized or invalid requests."
+				},
+				{
+					"name": "LicenseTests",
+					"item": [
+						{
+							"name": "RegisterMachineTests",
+							"item": [
+								{
+									"name": "InvalidMachineID",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 400\", function () {\r",
+													"    pm.response.to.have.status(400);\r",
+													"});\r",
+													"\r",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{token}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"machineId\": \"machine15\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{url}}/Licence/admin/register",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"Licence",
+												"admin",
+												"register"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"description": "Verifies the functionality of the machine registration endpoint, ensuring correct handling of valid and invalid machine IDs."
+						}
+					],
+					"description": "Tests related to licensing operations, including machine registration and UUID generation for device identification."
 				}
 			],
 			"description": "Validate the security and functionality of authentication and authorization endpoints, ensuring proper access control and data handling."

--- a/Backend/UpFluxCollection.postman_collection.json
+++ b/Backend/UpFluxCollection.postman_collection.json
@@ -1152,6 +1152,60 @@
 								}
 							],
 							"description": "Verifies the functionality of the machine registration endpoint, ensuring correct handling of valid and invalid machine IDs."
+						},
+						{
+							"name": "GenerateUUIDTests",
+							"item": [
+								{
+									"name": "GenerateValidMachineID",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {\r",
+													"    pm.response.to.have.status(200);\r",
+													"});\r",
+													"\r",
+													"pm.test(\"Response body contains machineId\", function () {\r",
+													"    pm.expect(pm.response.json()).to.have.property('machineId');\r",
+													"});\r",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{token}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{url}}/Licence/admin/generateId",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"Licence",
+												"admin",
+												"generateId"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"description": "Tests the UUID generation endpoint to confirm that a valid UUID is consistently produced and handles unauthorized access properly."
 						}
 					],
 					"description": "Tests related to licensing operations, including machine registration and UUID generation for device identification."

--- a/Backend/UpFluxCollection.postman_collection.json
+++ b/Backend/UpFluxCollection.postman_collection.json
@@ -1203,6 +1203,51 @@
 										}
 									},
 									"response": []
+								},
+								{
+									"name": "GenerateInValidMachineID",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 401\", function () {\r",
+													"    pm.response.to.have.status(401);\r",
+													"});\r",
+													"\r",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{token}}+x",
+													"type": "string"
+												}
+											]
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{url}}/Licence/admin/generateId",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"Licence",
+												"admin",
+												"generateId"
+											]
+										}
+									},
+									"response": []
 								}
 							],
 							"description": "Tests the UUID generation endpoint to confirm that a valid UUID is consistently produced and handles unauthorized access properly."

--- a/Backend/UpFluxCollection.postman_collection.json
+++ b/Backend/UpFluxCollection.postman_collection.json
@@ -1043,6 +1043,17 @@
 													"    pm.response.to.have.status(400);\r",
 													"});\r",
 													"\r",
+													"// Test to verify the specific error message\r",
+													"pm.test(\"Error response structure and message validation\", function () {\r",
+													"    var responseData = pm.response.json();\r",
+													"\r",
+													"    // Verify the error message for MachineId\r",
+													"    pm.expect(responseData).to.have.property(\"errors\");\r",
+													"    pm.expect(responseData.errors).to.have.property(\"MachineId\");\r",
+													"    pm.expect(responseData.errors.MachineId).to.be.an('array').that.includes(\"The MachineId field is required.\");\r",
+													"\r",
+													"});\r",
+													"\r",
 													""
 												],
 												"type": "text/javascript",
@@ -1065,7 +1076,60 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\r\n  \"machineId\": \"machine15\"\r\n}",
+											"raw": "{\r\n  \"machineId\": \"\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{url}}/Licence/admin/register",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"Licence",
+												"admin",
+												"register"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "InvalidAdminToken",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Unauthorized access returns 401\", function () {\r",
+													"    pm.response.to.have.status(401);\r",
+													"});\r",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{token}}+x",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n  \"machineId\": \"M1\"\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"


### PR DESCRIPTION
For this task I have implemented the following test cases:

1. I have created Invalid machine id using a wrong id or empty machine id.
2. I have Implemented an invalid admin token test case to check if we can add a new machine.
3. I have done the generate a valid machine id test case using valid credential and auth token.
4. I have created the generate a invalid machine id test case using auth token.

![image](https://github.com/user-attachments/assets/f4edecad-846b-497f-a11c-f8d578d1203e)
